### PR TITLE
fix: add wasi logging import

### DIFF
--- a/docs/tour/add-features.mdx
+++ b/docs/tour/add-features.mdx
@@ -187,6 +187,7 @@ package wasmcloud:hello;
 
 world hello {
   include wasmcloud:component-go/imports@0.1.0;
+  import wasi:logging/logging@0.1.0-draft; // [!code ++]
   import wasi:keyvalue/atomics@0.2.0-draft; // [!code ++]
   import wasi:keyvalue/store@0.2.0-draft; // [!code ++]
 


### PR DESCRIPTION
This commit adds the missing wasi logging import to the Golang quickstart